### PR TITLE
More robust playback state sync

### DIFF
--- a/ClientProject/ClientSource/Plugin.cs
+++ b/ClientProject/ClientSource/Plugin.cs
@@ -37,6 +37,27 @@ namespace BarotraumaRadio
                 }
             });
 
+            GameMain.LuaCs.Networking.Receive("SetStateFromServer", (object[] args) =>
+            {
+                GameMain.LuaCs.PrintMessage("Received SetStateFromServer");
+                IReadMessage message = (IReadMessage)args[0];
+                PlayDataStruct dataStruct = INetSerializableStruct.Read<PlayDataStruct>(message);
+                Item? item = Item.ItemList.FirstOrDefault(serverItem => serverItem.ID == dataStruct.RadioID);
+                if (item == null)
+                    return;
+                ItemComponent? component = item.Components.FirstOrDefault(c => c is Radio);
+                if (component != null && component is Radio radioComponent && radioComponent.ServerSync)
+                {
+                    if(radioComponent.RadioEnabled == dataStruct.Playing)
+                    {
+                        GameMain.LuaCs.PrintMessage("Radio state already set to " + dataStruct.Playing);
+                        return;
+                    }
+                    radioComponent.RadioEnabled = dataStruct.Playing;
+                }
+                GameMain.LuaCs.PrintMessage("Radio state set to " + dataStruct.Playing);
+            });
+
             GameMain.LuaCs.Networking.Receive("SendStringFromServer", (object[] args) =>
             {
                 IReadMessage message = (IReadMessage)args[0];

--- a/ServerProject/ServerSource/Plugin.cs
+++ b/ServerProject/ServerSource/Plugin.cs
@@ -1,6 +1,7 @@
 ﻿using Barotrauma;
 using Barotrauma.Items.Components;
 using Barotrauma.Networking;
+using System.Text.Json;
 
 namespace BarotraumaRadio
 {
@@ -26,6 +27,17 @@ namespace BarotraumaRadio
                     SendStringToClient("6");
                     radioComponent.ServerUrl = dataStruct.ParamValue!;
                 }
+            });
+
+            GameMain.LuaCs.Networking.Receive("SetStateFromClient", (object[] args) =>
+            {
+                GameMain.LuaCs.PrintMessage("Received set state from client");
+                IReadMessage message = (IReadMessage)args[0];
+                INetSerializableStruct dataStruct = INetSerializableStruct.Read<PlayDataStruct>(message);
+                IWriteMessage msg = GameMain.LuaCs.Networking.Start("SetStateFromServer");
+                dataStruct.Write(msg);
+                GameMain.LuaCs.Networking.Send(msg);
+                GameMain.LuaCs.PrintMessage("Sent set state to clients");
             });
 
             GameMain.LuaCs.Networking.Receive("RequestStationFromClient", (object[] args) =>

--- a/SharedProject/SharedSource/RadioDataStruct.cs
+++ b/SharedProject/SharedSource/RadioDataStruct.cs
@@ -18,5 +18,24 @@ namespace BarotraumaRadio
         public RadioDataStruct()
         {
         }
-    };
+    }
+
+    public class PlayDataStruct : INetSerializableStruct
+    {
+        [NetworkSerialize]
+        public int? RadioID;
+        [NetworkSerialize]
+        public bool Playing;
+
+        public PlayDataStruct(int radioID, bool playing)
+        {
+            RadioID = radioID;
+            Playing = playing;
+        }
+
+        public PlayDataStruct()
+        {
+            Playing = false;
+        }
+    }
 }


### PR DESCRIPTION
Hey, I tested this a bit in MP and found that the playback state often inverted/desynced between clients so I tried doing an absolute sync for it. This also fixes a discrepancy between the remote and wiring control interfaces. Not sure if this holds under all conditions (for instance, not sure if sync is triggered when a player joins) but so far seems pretty solid. 

I do still have an error that serversync seems to be active in the sub editor, which causes a crash when pressing play. No idea what all the correct checks for MP/SP/sub are. Could also be my config that's broken :P